### PR TITLE
Port upstream Pillow 10.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing to Unikraft
+
+Contributions to Unikraft are welcome!
+Please refer to the [Contributing](https://unikraft.org/docs/contributing/) page for further information.

--- a/Config.uk
+++ b/Config.uk
@@ -1,0 +1,4 @@
+config LIBPYTHON_PILLOW
+    bool "Pillow - Python Imaging Library"
+    default n
+    select LIBPYTHON3

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,0 +1,190 @@
+#  Pillow Makefile.uk
+#
+#  Authors: Andrei Tatar <andrei@unikraft.io>
+#
+#  Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+################################################################################
+# Library registration
+##############################################################################
+$(eval $(call addlib_s,libpython_pillow,$(CONFIG_LIBPYTHON_PILLOW)))
+
+################################################################################
+# Sources
+##############################################################################
+LIBPYTHON_PILLOW_VERSION=10.0.0
+LIBPYTHON_PILLOW_URL=https://github.com/python-pillow/Pillow/archive/refs/tags/$(LIBPYTHON_PILLOW_VERSION).tar.gz
+LIBPYTHON_PILLOW_DIRNAME=Pillow-$(LIBPYTHON_PILLOW_VERSION)
+LIBPYTHON_PILLOW_PATCHDIR=$(LIBPYTHON_PILLOW_BASE)/patches
+$(eval $(call fetch,libpython_pillow,$(LIBPYTHON_PILLOW_URL)))
+$(eval $(call patch,libpython_pillow,$(LIBPYTHON_PILLOW_PATCHDIR),$(LIBPYTHON_PILLOW_DIRNAME)))
+
+################################################################################
+# Helpers
+##############################################################################
+LIBPYTHON_PILLOW_SRC = $(LIBPYTHON_PILLOW_ORIGIN)/$(LIBPYTHON_PILLOW_DIRNAME)
+
+################################################################################
+# Library includes
+##############################################################################
+
+################################################################################
+# Global flags
+##############################################################################
+LIBPYTHON_PILLOW_CFLAGS-y += -fexceptions
+LIBPYTHON_PILLOW_CFLAGS-y += -fasynchronous-unwind-tables
+LIBPYTHON_PILLOW_CFLAGS-y += -fwrapv
+
+LIBPYTHON_PILLOW_CFLAGS-y += -DPILLOW_VERSION=\"$(LIBPYTHON_PILLOW_VERSION)\"
+LIBPYTHON_PILLOW_CFLAGS-y += -DDYNAMIC_ANNOTATIONS_ENABLED=1
+LIBPYTHON_PILLOW_CFLAGS-y += -D_GNU_SOURCE
+
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBJPEG) += -DHAVE_LIBJPEG
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBOPENJPEG) += -DHAVE_OPENJPEG
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBZLIB) += -DHAVE_LIBZ
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBTIFF) += -DHAVE_LIBTIFF
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBRAQM) += -DHAVE_RAQM -DHAVE_RAQM_SYSTEM
+LIBPYTHON_PILLOW_CFLAGS-$(CONFIG_LIBWEBP_MUX) += -DHAVE_WEBPMUX
+
+LIBPYTHON_PILLOW_CFLAGS-y += -Werror=format-security
+LIBPYTHON_PILLOW_CFLAGS-y += -Wsign-compare
+
+LIBPYTHON_PILLOW_CFLAGS-y += -Wno-missing-field-initializers
+LIBPYTHON_PILLOW_CFLAGS-y += -Wno-implicit-fallthrough
+LIBPYTHON_PILLOW_CFLAGS-y += -Wno-cast-function-type
+LIBPYTHON_PILLOW_CFLAGS-$(call have_gcc) += -Wno-old-style-declaration
+
+################################################################################
+# Library sources
+##############################################################################
+LIBPYTHON_PILLOW_SRCS-$(CONFIG_LIBLITTLECMS) += $(LIBPYTHON_PILLOW_SRC)/src/_imagingcms.c
+LIBPYTHON_PILLOW_SRCS-$(CONFIG_LIBWEBP) += $(LIBPYTHON_PILLOW_SRC)/src/_webp.c
+LIBPYTHON_PILLOW_SRCS-$(CONFIG_LIBFREETYPE) += $(LIBPYTHON_PILLOW_SRC)/src/_imagingft.c
+
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/_imaging.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/Tk/tkImaging.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/_imagingmath.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/_imagingmorph.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/decode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/_imagingtk.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/display.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/encode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Access.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/AlphaComposite.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Bands.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/BcnDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/BitDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Blend.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/BoxBlur.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Chops.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/ColorLUT.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Convert.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/ConvertYCbCr.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Copy.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Crop.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Dib.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Draw.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Effects.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/EpsEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/File.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Fill.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Filter.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/FliDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Geometry.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/GetBBox.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/GifDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/GifEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/HexDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Histo.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Jpeg2KDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Jpeg2KEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/JpegDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/JpegEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Matrix.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/ModeFilter.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Negative.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Offset.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Pack.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/PackDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Palette.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Paste.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/PcdDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/PcxDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/PcxEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Point.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Quant.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/QuantHash.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/QuantHeap.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/QuantOctree.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/QuantPngQuant.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/RankFilter.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/RawDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/RawEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Reduce.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Resample.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/SgiRleDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Storage.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/SunRleDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/TgaRleDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/TgaRleEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/TiffDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/Unpack.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/UnpackYCC.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/UnsharpMask.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/XbmDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/XbmEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/ZipDecode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/ZipEncode.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/libImaging/codec_fd.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/map.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/outline.c
+LIBPYTHON_PILLOW_SRCS-y += $(LIBPYTHON_PILLOW_SRC)/src/path.c
+
+
+################################################################################
+# Root filesystem
+##############################################################################
+
+ifeq ($(CONFIG_LIBPYTHON_PILLOW),y)
+# Install into main python rootfs & cleanup non-python files
+$(PYTHON_ROOTFS)/.pillow_done: $(PYTHON_ROOTFS)/.keep
+	. $(PYTHON_ROOTFS)/bin/activate && cd $(LIBPYTHON_PILLOW_SRC) && pip install . --prefix=$(PYTHON_ROOTFS) --no-compile
+	_dir=`find "$(PYTHON_ROOTFS)" -maxdepth 4 -type d -name PIL`; \
+	find "$$_dir" -type f -name '*.so' -delete; \
+	find "$$_dir" -type d -name '__pycache__' | xargs rm -rf; \
+	find "$$_dir" -type f | grep -v '\.py$$' | tr "\n" "\0" | xargs -0 rm; \
+	find "$(LIBPYTHON_PILLOW_BASE)/importfix/PIL" -mindepth 1 -maxdepth 1 | xargs $(CP) -rp -t "$$_dir"; \
+	test `basename $$(dirname $$_dir) | cut -d. -f1,2` != $(LIBPYTHON3_VERSION) && \
+		mv "$$_dir" "$(PYTHON_ROOTFS)/lib/python$(LIBPYTHON3_VERSION)/PIL"
+	touch $@
+
+# Add Pillow rootfs to main python
+python-rootfs: $(PYTHON_ROOTFS)/.pillow_done
+
+endif

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# lib-python-pillow
-The Python Imaging Library
+# Pillow Python extension for Unikraft
+
+This is a port of the [Pillow](https://python-pillow.org/) Python extension to Unikraft.
+
+Please refer to `README.md` in the main unikraft repository as well as the [Unikraft Homepage](https://unikraft.org/) for further information.

--- a/importfix/PIL/_imaging.py
+++ b/importfix/PIL/_imaging.py
@@ -1,0 +1,1 @@
+from PIL__imaging import *

--- a/importfix/PIL/_imagingcms.py
+++ b/importfix/PIL/_imagingcms.py
@@ -1,0 +1,1 @@
+from PIL__imagingcms import *

--- a/importfix/PIL/_imagingft.py
+++ b/importfix/PIL/_imagingft.py
@@ -1,0 +1,1 @@
+from PIL__imagingft import *

--- a/importfix/PIL/_imagingmath.py
+++ b/importfix/PIL/_imagingmath.py
@@ -1,0 +1,1 @@
+from PIL__imagingmath import *

--- a/importfix/PIL/_imagingmorph.py
+++ b/importfix/PIL/_imagingmorph.py
@@ -1,0 +1,1 @@
+from PIL__imagingmorph import *

--- a/importfix/PIL/_imagingtk.py
+++ b/importfix/PIL/_imagingtk.py
@@ -1,0 +1,1 @@
+from PIL__imagingtk import *

--- a/importfix/PIL/_webp.py
+++ b/importfix/PIL/_webp.py
@@ -1,0 +1,1 @@
+from PIL__webp import *

--- a/patches/0001-Replace-duplicate-definitions-with-declarations.patch
+++ b/patches/0001-Replace-duplicate-definitions-with-declarations.patch
@@ -1,0 +1,40 @@
+From 6b66240778d89cb916a90c8c1de2f20cfc1d5176 Mon Sep 17 00:00:00 2001
+From: Andrei Tatar <andrei@unikraft.io>
+Date: Thu, 24 Aug 2023 18:48:54 +0200
+Subject: [PATCH] Replace duplicate definitions with declarations
+
+The Pillow codebase contained duplicate definitions of functions in
+compilation units. These units were never intended to be linked together
+in the upstream build but do get linked in Unikraft resulting in errors.
+This patch replaces one of the duplicate definitions with a declaration.
+
+Signed-off-by: Andrei Tatar <andrei@unikraft.io>
+---
+ src/_webp.c | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/src/_webp.c b/src/_webp.c
+index fe63027fb..b2ab26236 100644
+--- a/src/_webp.c
++++ b/src/_webp.c
+@@ -21,15 +21,9 @@
+ 
+ #endif
+ 
+-void
+-ImagingSectionEnter(ImagingSectionCookie *cookie) {
+-    *cookie = (PyThreadState *)PyEval_SaveThread();
+-}
++void ImagingSectionEnter(ImagingSectionCookie *cookie);
+ 
+-void
+-ImagingSectionLeave(ImagingSectionCookie *cookie) {
+-    PyEval_RestoreThread((PyThreadState *)*cookie);
+-}
++void ImagingSectionLeave(ImagingSectionCookie *cookie);
+ 
+ /* -------------------------------------------------------------------- */
+ /* WebP Muxer Error Handling                                            */
+-- 
+2.41.0
+

--- a/patches/0002-Fix-assumption-of-malloc-0-NULL.patch
+++ b/patches/0002-Fix-assumption-of-malloc-0-NULL.patch
@@ -1,0 +1,44 @@
+From 9b08182b2453d2283cad7361e9f4220e9b1c2976 Mon Sep 17 00:00:00 2001
+From: Andrei Tatar <andrei@unikraft.io>
+Date: Fri, 25 Aug 2023 15:25:21 +0200
+Subject: [PATCH 2/2] Fix assumption of malloc(0) != NULL
+
+This patch fixes allocation code that fails when malloc(0) == NULL,
+which is explicitly permitted by the standard, by only attempting to
+allocate nonzero sizes or not erroring when the requested size is 0.
+
+Signed-off-by: Andrei Tatar <andrei@unikraft.io>
+---
+ src/libImaging/Draw.c    | 2 +-
+ src/libImaging/Storage.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libImaging/Draw.c b/src/libImaging/Draw.c
+index 82f290bd0..48108d7b4 100644
+--- a/src/libImaging/Draw.c
++++ b/src/libImaging/Draw.c
+@@ -478,7 +478,7 @@ polygon_generic(Imaging im, int n, Edge *e, int ink, int eofill, hline_handler h
+     /* Process the edge table with a scan line searching for intersections */
+     /* malloc check ok, using calloc */
+     xx = calloc(edge_count * 2, sizeof(float));
+-    if (!xx) {
++    if (!xx && edge_count) {
+         free(edge_table);
+         return -1;
+     }
+diff --git a/src/libImaging/Storage.c b/src/libImaging/Storage.c
+index 128595f65..e539bf4c0 100644
+--- a/src/libImaging/Storage.c
++++ b/src/libImaging/Storage.c
+@@ -286,7 +286,7 @@ ImagingMemorySetBlocksMax(ImagingMemoryArena arena, int blocks_max) {
+             return 0;
+         }
+         arena->blocks_pool = p;
+-    } else {
++    } else if (blocks_max) {
+         arena->blocks_pool = calloc(sizeof(*arena->blocks_pool), blocks_max);
+         if (!arena->blocks_pool) {
+             return 0;
+-- 
+2.41.0
+


### PR DESCRIPTION
This work is based off Pillow 10.0.0 configured on Linux x86_64 and adapted to work with Unikraft.
Files under importfix/ are correctly namespaced wrapper modules for any binary modules that we compile and link into Unikraft, and must be copied over to the python rootfs.
Selecting this library will add its files to the python rootfs build.

This depends on, or integrates with, the following PRs:
- https://github.com/unikraft/lib-libpng/pull/3
- https://github.com/unikraft/lib-libtiff/pull/3
- https://github.com/unikraft/lib-openjpeg/pull/3
- https://github.com/unikraft/lib-fribidi/pull/1
- https://github.com/unikraft/lib-giflib/pull/1
- https://github.com/unikraft/lib-libdeflate/pull/1
- https://github.com/unikraft/lib-littlecms/pull/1
- https://github.com/unikraft/lib-xz/pull/1
- https://github.com/unikraft/lib-zstd/pull/1
- https://github.com/unikraft/lib-pixman/pull/1
- https://github.com/unikraft/lib-cairo/pull/1
- https://github.com/unikraft/lib-freetype/pull/1
- https://github.com/unikraft/lib-harfbuzz/pull/1
- https://github.com/unikraft/lib-libwebp/pull/1
- https://github.com/unikraft/lib-raqm/pull/1

Makefile library inclusion order (x86, replace intrinsics with appropriate arm ones if on arm):
```
# Libs
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libcxx
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libcxxabi
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libunwind
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-intel-intrinsics
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-compiler-rt
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-musl
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-newlib
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libffi
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-lwip
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-bzip2
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-sqlite
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-openssl
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libuuid
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-zlib
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libdeflate
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libjpeg
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-openjpeg
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-giflib
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libpng
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libwebp
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-lzma
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-xz
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-zstd
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-libtiff
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-pixman
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-freetype
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-cairo
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-littlecms
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-fribidi
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-harfbuzz
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-raqm
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-geos
# Python stuff
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-python3
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-python-numpy
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-python-shapely
LIBS-y := $(LIBS-y):$(UK_LIBS)/lib-python-pillow
```